### PR TITLE
wrap token comparisons in a function, proliferate it virtually everywhere apk-token was, and fix some related tab/space issues

### DIFF
--- a/jiracli/password.go
+++ b/jiracli/password.go
@@ -21,7 +21,7 @@ func (o *GlobalOptions) ProvideAuthParams() *jiradata.AuthParams {
 
 func (o *GlobalOptions) keyName() string {
 	user := o.Login.Value
-	if o.AuthMethod() == "api-token" {
+	if o.AuthMethodIsToken() {
 		user = "api-token:" + user
 	}
 
@@ -133,14 +133,14 @@ func (o *GlobalOptions) GetPass() string {
 		return o.cachedPassword
 	}
 
-	if o.cachedPassword = os.Getenv("JIRA_API_TOKEN"); o.cachedPassword != "" && o.AuthMethod() == "api-token" {
+	if o.cachedPassword = os.Getenv("JIRA_API_TOKEN"); o.cachedPassword != "" && o.AuthMethodIsToken() {
 		return o.cachedPassword
 	}
 
 	prompt := fmt.Sprintf("Jira Password [%s]: ", o.Login)
 	help := ""
 
-	if o.AuthMethod() == "api-token" {
+	if o.AuthMethodIsToken() {
 		prompt = fmt.Sprintf("Jira API-Token [%s]: ", o.Login)
 		help = "API Tokens may be required by your Jira service endpoint: https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/"
 	}

--- a/jiracmd/logout.go
+++ b/jiracmd/logout.go
@@ -30,7 +30,7 @@ func CmdLogoutRegistry() *jiracli.CommandRegistryEntry {
 
 // CmdLogout will attempt to terminate an active Jira session
 func CmdLogout(o *oreo.Client, globals *jiracli.GlobalOptions, opts *jiracli.CommonOptions) error {
-	if (globals.AuthMethod() == "api-token" || globals.AuthMethod() == "bearer-token") {
+	if globals.AuthMethodIsToken() {
 		log.Noticef("No need to logout when using api-token or bearer-token authentication method")
 		if globals.GetPass() != "" && terminal.IsTerminal(int(os.Stdin.Fd())) && terminal.IsTerminal(int(os.Stdout.Fd())) {
 			delete := false


### PR DESCRIPTION
wrap token comparisons in a function, proliferate it virtually everywhere apk-token was, and fix some related tab/space issues